### PR TITLE
localhost should be AMPDBHOST

### DIFF
--- a/DB_Helper.class.php
+++ b/DB_Helper.class.php
@@ -256,7 +256,7 @@ if (!class_exists('Database')) {
 	class Database extends PDO {
 		public function __construct() {
 			global $amp_conf;
-			$dsn = "mysql:host=localhost;dbname=".$amp_conf['AMPDBNAME'];
+			$dsn = "mysql:host=".$amp_conf['AMPDBHOST'].";dbname=".$amp_conf['AMPDBNAME'];
 			$username = $amp_conf['AMPDBUSER'];
 			$password = $amp_conf['AMPDBPASS'];
 			parent::__construct($dsn, $username, $password);


### PR DESCRIPTION
Suggested fix for http://issues.freepbx.org/browse/FREEPBX-7275
localhost should be AMPDBHOST so it works when you move the database to another host.
