### PR TITLE
Add TLS and User Identity options for openldap authentication.

### DIFF
--- a/functions.inc/auth/modules/Msad.php
+++ b/functions.inc/auth/modules/Msad.php
@@ -738,6 +738,18 @@ class Msad extends Auth {
 		return $result;
 	}
 
+	public function sig_handler($signo) {
+		switch($signo) {
+			case SIGCLD:
+				while (($pid = pcntl_wait($signo, WNOHANG)) > 0) {
+					$signal = pcntl_wexitstatus($signo);
+					$this->active -= 1;
+				}
+
+				break;
+		}
+	}
+
 	/**
 	 * Debug messages
 	 * @param  string $message The message

--- a/functions.inc/auth/modules/Openldap.php
+++ b/functions.inc/auth/modules/Openldap.php
@@ -44,6 +44,11 @@ class Openldap extends Auth {
 	 */
 	private $port = 389;
 	/**
+	 * LDAP TLS
+	 * @var boolean
+	 */
+	private $tls = true;
+	/**
 	 * LDAP Base DN
 	 * @var string
 	 */
@@ -111,6 +116,7 @@ class Openldap extends Auth {
 		$config = $userman->getConfig("authOpenLDAPSettings");
 		$this->host = $config['host'];
 		$this->port = !empty($config['port']) ? $config['port'] : 389;
+		$this->tls = isset($config['tls']) ? $config['tls'] : true;
 		$this->basedn = $config['basedn'];
 		$this->userdn = $config['userdn'];
 		$this->user = $config['username'];
@@ -183,6 +189,7 @@ class Openldap extends Auth {
 		$config = array(
 			"host" => $_REQUEST['openldap-host'],
 			"port" => $_REQUEST['openldap-port'],
+			"tls" => $_REQUEST['openldap-tls'] === 'yes',
 			"username" => $_REQUEST['openldap-username'],
 			"password" => $_REQUEST['openldap-password'],
 			"userdn" => $_REQUEST['openldap-userdn'],
@@ -218,6 +225,10 @@ class Openldap extends Auth {
 	public function connect($reconnect = false) {
 		if($reconnect || !$this->ldap) {
 			$this->ldap = ldap_connect($this->host,$this->port);
+
+			if ($this->tls)
+				ldap_start_tls($this->ldap);
+
 			if($this->ldap === false) {
 				$this->ldap = null;
 				throw new \Exception("Unable to Connect");
@@ -673,7 +684,6 @@ class Openldap extends Auth {
 		$this->connect();
 
 		$this->out("Retrieving all users...",false);
-
 		$sr = ldap_search($this->ldap, $this->basedn, "(&(objectClass=".$this->userObjectClass.")(uid=*))");
 		$users = ldap_get_entries($this->ldap, $sr);
 

--- a/functions.inc/auth/modules/Openldap.php
+++ b/functions.inc/auth/modules/Openldap.php
@@ -228,8 +228,9 @@ class Openldap extends Auth {
 		if($reconnect || !$this->ldap) {
 			$this->ldap = ldap_connect($this->host,$this->port);
 
-			if ($this->tls)
+			if ($this->tls) {
 				ldap_start_tls($this->ldap);
+			}
 
 			if($this->ldap === false) {
 				$this->ldap = null;

--- a/functions.inc/auth/modules/Openldap.php
+++ b/functions.inc/auth/modules/Openldap.php
@@ -118,6 +118,7 @@ class Openldap extends Auth {
 		$this->port = !empty($config['port']) ? $config['port'] : 389;
 		$this->tls = isset($config['tls']) ? $config['tls'] : true;
 		$this->basedn = $config['basedn'];
+		$this->userident = isset($config['userident']) ? $config['userident'] : 'uid';
 		$this->userdn = $config['userdn'];
 		$this->user = $config['username'];
 		$this->password = $config['password'];
@@ -192,6 +193,7 @@ class Openldap extends Auth {
 			"tls" => $_REQUEST['openldap-tls'] === 'yes',
 			"username" => $_REQUEST['openldap-username'],
 			"password" => $_REQUEST['openldap-password'],
+			"userident" => $_REQUEST['openldap-userident'],
 			"userdn" => $_REQUEST['openldap-userdn'],
 			"basedn" => $_REQUEST['openldap-basedn'],
 			"la" => $_REQUEST['openldap-la'],

--- a/i18n/bg_BG/LC_MESSAGES/userman.po
+++ b/i18n/bg_BG/LC_MESSAGES/userman.po
@@ -784,6 +784,10 @@ msgstr ""
 msgid "The OpenLDAP port"
 msgstr ""
 
+#: views/openldap.php:51
+msgid "Use TLS"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/bg_BG/LC_MESSAGES/userman.po
+++ b/i18n/bg_BG/LC_MESSAGES/userman.po
@@ -788,6 +788,10 @@ msgstr ""
 msgid "Use TLS"
 msgstr ""
 
+#: views/openldap.php:134
+msgid "The OpenLDAP User Identity. Usually is uid"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/es_ES/LC_MESSAGES/userman.po
+++ b/i18n/es_ES/LC_MESSAGES/userman.po
@@ -798,6 +798,10 @@ msgstr ""
 msgid "The OpenLDAP port"
 msgstr ""
 
+#: views/openldap.php:51
+msgid "Use TLS"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/es_ES/LC_MESSAGES/userman.po
+++ b/i18n/es_ES/LC_MESSAGES/userman.po
@@ -802,6 +802,10 @@ msgstr ""
 msgid "Use TLS"
 msgstr ""
 
+#: views/openldap.php:134
+msgid "The OpenLDAP User Identity. Usually is uid"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/fa_IR/LC_MESSAGES/userman.po
+++ b/i18n/fa_IR/LC_MESSAGES/userman.po
@@ -820,6 +820,10 @@ msgstr ""
 msgid "The OpenLDAP port"
 msgstr ""
 
+#: views/openldap.php:51
+msgid "Use TLS"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/fa_IR/LC_MESSAGES/userman.po
+++ b/i18n/fa_IR/LC_MESSAGES/userman.po
@@ -824,6 +824,10 @@ msgstr ""
 msgid "Use TLS"
 msgstr ""
 
+#: views/openldap.php:134
+msgid "The OpenLDAP User Identity. Usually is uid"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/fr_FR/LC_MESSAGES/userman.po
+++ b/i18n/fr_FR/LC_MESSAGES/userman.po
@@ -777,6 +777,10 @@ msgstr ""
 msgid "The OpenLDAP port"
 msgstr ""
 
+#: views/openldap.php:51
+msgid "Use TLS"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/fr_FR/LC_MESSAGES/userman.po
+++ b/i18n/fr_FR/LC_MESSAGES/userman.po
@@ -781,6 +781,10 @@ msgstr ""
 msgid "Use TLS"
 msgstr ""
 
+#: views/openldap.php:134
+msgid "The OpenLDAP User Identity. Usually is uid"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/ja_JP/LC_MESSAGES/userman.po
+++ b/i18n/ja_JP/LC_MESSAGES/userman.po
@@ -819,6 +819,10 @@ msgstr ""
 msgid "Use TLS"
 msgstr ""
 
+#: views/openldap.php:134
+msgid "The OpenLDAP User Identity. Usually is uid"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/ja_JP/LC_MESSAGES/userman.po
+++ b/i18n/ja_JP/LC_MESSAGES/userman.po
@@ -815,6 +815,10 @@ msgstr ""
 msgid "The OpenLDAP port"
 msgstr ""
 
+#: views/openldap.php:51
+msgid "Use TLS"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/pl/LC_MESSAGES/userman.po
+++ b/i18n/pl/LC_MESSAGES/userman.po
@@ -776,6 +776,10 @@ msgstr ""
 msgid "Use TLS"
 msgstr ""
 
+#: views/openldap.php:134
+msgid "The OpenLDAP User Identity. Usually is uid"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/pl/LC_MESSAGES/userman.po
+++ b/i18n/pl/LC_MESSAGES/userman.po
@@ -772,6 +772,10 @@ msgstr ""
 msgid "The OpenLDAP port"
 msgstr ""
 
+#: views/openldap.php:51
+msgid "Use TLS"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/zh_CN/LC_MESSAGES/userman.po
+++ b/i18n/zh_CN/LC_MESSAGES/userman.po
@@ -777,6 +777,10 @@ msgstr ""
 msgid "Use TLS"
 msgstr ""
 
+#: views/openldap.php:134
+msgid "The OpenLDAP User Identity. Usually is uid"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/i18n/zh_CN/LC_MESSAGES/userman.po
+++ b/i18n/zh_CN/LC_MESSAGES/userman.po
@@ -773,6 +773,10 @@ msgstr ""
 msgid "The OpenLDAP port"
 msgstr ""
 
+#: views/openldap.php:51
+msgid "Use TLS"
+msgstr ""
+
 #: views/openldap.php:63
 msgid "The OpenLDAP username"
 msgstr ""

--- a/views/openldap.php
+++ b/views/openldap.php
@@ -119,6 +119,28 @@
 			<div class="row">
 				<div class="form-group">
 					<div class="col-md-3">
+						<label class="control-label" for="openldap-userident"><?php echo _("User Identity")?></label>
+						<i class="fa fa-question-circle fpbx-help-icon" data-for="openldap-userident"></i>
+					</div>
+					<div class="col-md-9">
+						<input id="openldap-userident" name="openldap-userident" type="text" class="form-control" value="<?php echo isset($config['userident']) ? $config['userident'] : 'uid'?>">
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-md-12">
+			<span id="openldap-userident-help" class="help-block fpbx-help-block"><?php echo _("The OpenLDAP User Identity. Usually is uid")?></span>
+		</div>
+	</div>
+</div>
+<div class="element-container">
+	<div class="row">
+		<div class="col-md-12">
+			<div class="row">
+				<div class="form-group">
+					<div class="col-md-3">
 						<label class="control-label" for="openldap-userdn"><?php echo _("User DN")?></label>
 						<i class="fa fa-question-circle fpbx-help-icon" data-for="openldap-userdn"></i>
 					</div>

--- a/views/openldap.php
+++ b/views/openldap.php
@@ -48,6 +48,33 @@
 			<div class="row">
 				<div class="form-group">
 					<div class="col-md-3">
+						<label class="control-label" for="openldap-post"><?php echo _("Use TLS")?></label>
+						<i class="fa fa-question-circle fpbx-help-icon" data-for="openldap-tls"></i>
+					</div>
+						<div class="col-md-9">
+							<span class="radioset">
+								<input type="radio" id="tls-yes" name="openldap-tls" value="yes" <?php echo (!isset($config['tls']) || $config['tls']) ? "checked" : ""?>>
+								<label for="tls-yes"><?php echo _("Yes")?></label>
+								<input type="radio" id="tls-no" name="openldap-tls" value="no" <?php echo (isset($config['tls']) && !($config['tls'])) ? "checked" : ""?>>
+								<label for="tls-no"><?php echo _("No")?></label>
+							</span>
+						</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-md-12">
+			<span id="openldap-tls-help" class="help-block fpbx-help-block"><?php echo _("Use TLS")?></span>
+		</div>
+	</div>
+</div>
+<div class="element-container">
+	<div class="row">
+		<div class="col-md-12">
+			<div class="row">
+				<div class="form-group">
+					<div class="col-md-3">
 						<label class="control-label" for="openldap-host"><?php echo _("Username")?></label>
 						<i class="fa fa-question-circle fpbx-help-icon" data-for="openldap-username"></i>
 					</div>


### PR DESCRIPTION
I have added:
- an option in User Manager -> Settings -> Authentication Settings to allow to use TLS for ldap authentication. Without it you cannot sync users against an ldap server that uses that kind of authentication. The default value is to use the TLS authentication.
- the User Identity field to allow to configure user identity for ldap.
- a missing sig_handler func to Msad class.
