### PR TITLE
Add display name attribute in open ldap settings.

### DIFF
--- a/functions.inc/auth/modules/Openldap.php
+++ b/functions.inc/auth/modules/Openldap.php
@@ -74,6 +74,11 @@ class Openldap extends Auth {
 	 */
 	private $userident = "uid";
 	/**
+	 * LDAP Display Name
+	 * @var string
+	 */
+	private $displayname = "displayname";
+	/**
 	 * LDAP Object Class of a user
 	 * @var string
 	 */
@@ -119,6 +124,7 @@ class Openldap extends Auth {
 		$this->tls = isset($config['tls']) ? $config['tls'] : true;
 		$this->basedn = $config['basedn'];
 		$this->userident = isset($config['userident']) ? $config['userident'] : 'uid';
+		$this->displayname = isset($config['displayname']) ? $config['displayname'] : 'displayname';
 		$this->userdn = $config['userdn'];
 		$this->user = $config['username'];
 		$this->password = $config['password'];
@@ -194,6 +200,7 @@ class Openldap extends Auth {
 			"username" => $_REQUEST['openldap-username'],
 			"password" => $_REQUEST['openldap-password'],
 			"userident" => $_REQUEST['openldap-userident'],
+			"displayname" => $_REQUEST['openldap-displayname'],
 			"userdn" => $_REQUEST['openldap-userdn'],
 			"basedn" => $_REQUEST['openldap-basedn'],
 			"la" => $_REQUEST['openldap-la'],
@@ -704,7 +711,7 @@ class Openldap extends Auth {
 					"primary_group" => !empty($user['gidnumber'][0]) ? $user['gidnumber'][0] : '',
 					"fname" => !empty($user['givenname'][0]) ? $user['givenname'][0] : '',
 					"lname" => !empty($user['sn'][0]) ? $user['sn'][0] : '',
-					"displayname" => !empty($user['displayname'][0]) ?$user['displayname'][0] : '',
+					"displayname" => !empty($user[$this->displayname][0]) ?$user[$this->displayname][0] : '',
 					"department" => !empty($user['department'][0]) ? $user['department'][0] : '',
 					"email" => !empty($user['mail'][0]) ? $user['mail'][0] : '',
 					"cell" => !empty($user['mobile'][0]) ? $user['mobile'][0] : '',

--- a/i18n/bg_BG/LC_MESSAGES/userman.po
+++ b/i18n/bg_BG/LC_MESSAGES/userman.po
@@ -771,6 +771,9 @@ msgstr ""
 msgid "The OpenLDAP User Identity. Usually is uid"
 msgstr ""
 
+msgid "The OpenLDAP Display Name. Usually is displayname"
+msgstr ""
+
 #: views/openldap.php:156
 msgid ""
 "The OpenLDAP User-DN. Usually in the format of OU=people,DC=example,DC=com)"
@@ -1071,6 +1074,9 @@ msgstr ""
 
 #: views/openldap.php:122
 msgid "User Identity"
+msgstr ""
+
+msgid "Display Name"
 msgstr ""
 
 #: userman.i18n.php:4 userman.i18n.php:10

--- a/i18n/es_ES/LC_MESSAGES/userman.po
+++ b/i18n/es_ES/LC_MESSAGES/userman.po
@@ -785,6 +785,9 @@ msgstr ""
 msgid "The OpenLDAP User Identity. Usually is uid"
 msgstr ""
 
+msgid "The OpenLDAP Display Name. Usually is displayname"
+msgstr ""
+
 #: views/openldap.php:156
 msgid ""
 "The OpenLDAP User-DN. Usually in the format of OU=people,DC=example,DC=com)"
@@ -1085,6 +1088,9 @@ msgstr "Usuario No Existe"
 
 #: views/openldap.php:122
 msgid "User Identity"
+msgstr ""
+
+msgid "Display Name"
 msgstr ""
 
 #: userman.i18n.php:4 userman.i18n.php:10

--- a/i18n/fa_IR/LC_MESSAGES/userman.po
+++ b/i18n/fa_IR/LC_MESSAGES/userman.po
@@ -807,6 +807,9 @@ msgstr ""
 msgid "The OpenLDAP User Identity. Usually is uid"
 msgstr ""
 
+msgid "The OpenLDAP Display Name. Usually is displayname"
+msgstr ""
+
 #: views/openldap.php:156
 msgid ""
 "The OpenLDAP User-DN. Usually in the format of OU=people,DC=example,DC=com)"
@@ -1115,6 +1118,9 @@ msgstr "کاربر وجود ندارد"
 
 #: views/openldap.php:122
 msgid "User Identity"
+msgstr ""
+
+msgid "Display Name"
 msgstr ""
 
 #: userman.i18n.php:4 userman.i18n.php:10

--- a/i18n/fr_FR/LC_MESSAGES/userman.po
+++ b/i18n/fr_FR/LC_MESSAGES/userman.po
@@ -764,6 +764,9 @@ msgstr ""
 msgid "The OpenLDAP User Identity. Usually is uid"
 msgstr ""
 
+msgid "The OpenLDAP Display Name. Usually is displayname"
+msgstr ""
+
 #: views/openldap.php:156
 msgid ""
 "The OpenLDAP User-DN. Usually in the format of OU=people,DC=example,DC=com)"
@@ -1064,6 +1067,9 @@ msgstr "L'utilisateur n'existe pas"
 
 #: views/openldap.php:122
 msgid "User Identity"
+msgstr ""
+
+msgid "Display Name"
 msgstr ""
 
 #: userman.i18n.php:4 userman.i18n.php:10

--- a/i18n/ja_JP/LC_MESSAGES/userman.po
+++ b/i18n/ja_JP/LC_MESSAGES/userman.po
@@ -802,6 +802,9 @@ msgstr ""
 msgid "The OpenLDAP User Identity. Usually is uid"
 msgstr ""
 
+msgid "The OpenLDAP Display Name. Usually is displayname"
+msgstr ""
+
 #: views/openldap.php:156
 msgid ""
 "The OpenLDAP User-DN. Usually in the format of OU=people,DC=example,DC=com)"
@@ -1104,6 +1107,9 @@ msgstr "ユーザーは存在しません"
 
 #: views/openldap.php:122
 msgid "User Identity"
+msgstr ""
+
+msgid "Display Name"
 msgstr ""
 
 #: userman.i18n.php:4 userman.i18n.php:10

--- a/i18n/pl/LC_MESSAGES/userman.po
+++ b/i18n/pl/LC_MESSAGES/userman.po
@@ -759,6 +759,9 @@ msgstr ""
 msgid "The OpenLDAP User Identity. Usually is uid"
 msgstr ""
 
+msgid "The OpenLDAP Display Name. Usually is displayname"
+msgstr ""
+
 #: views/openldap.php:156
 msgid ""
 "The OpenLDAP User-DN. Usually in the format of OU=people,DC=example,DC=com)"
@@ -1059,6 +1062,9 @@ msgstr ""
 
 #: views/openldap.php:122
 msgid "User Identity"
+msgstr ""
+
+msgid "Display Name"
 msgstr ""
 
 #: userman.i18n.php:4 userman.i18n.php:10

--- a/i18n/userman.pot
+++ b/i18n/userman.pot
@@ -824,6 +824,9 @@ msgstr ""
 msgid "The OpenLDAP User Identity. Usually is uid"
 msgstr ""
 
+msgid "The OpenLDAP Display Name. Usually is displayname"
+msgstr ""
+
 #: views/openldap.php:156
 msgid ""
 "The OpenLDAP User-DN. Usually in the format of OU=people,DC=example,DC=com)"
@@ -1135,6 +1138,9 @@ msgstr ""
 
 #: views/openldap.php:122
 msgid "User Identity"
+msgstr ""
+
+msgid "Display Name"
 msgstr ""
 
 #: userman.i18n.php:4

--- a/i18n/zh_CN/LC_MESSAGES/userman.po
+++ b/i18n/zh_CN/LC_MESSAGES/userman.po
@@ -760,6 +760,9 @@ msgstr ""
 msgid "The OpenLDAP User Identity. Usually is uid"
 msgstr ""
 
+msgid "The OpenLDAP Display Name. Usually is displayname"
+msgstr ""
+
 #: views/openldap.php:156
 msgid ""
 "The OpenLDAP User-DN. Usually in the format of OU=people,DC=example,DC=com)"
@@ -1060,6 +1063,9 @@ msgstr ""
 
 #: views/openldap.php:122
 msgid "User Identity"
+msgstr ""
+
+msgid "Display Name"
 msgstr ""
 
 #: userman.i18n.php:4 userman.i18n.php:10

--- a/views/openldap.php
+++ b/views/openldap.php
@@ -141,6 +141,28 @@
 			<div class="row">
 				<div class="form-group">
 					<div class="col-md-3">
+						<label class="control-label" for="openldap-displayname"><?php echo _("Display Name")?></label>
+						<i class="fa fa-question-circle fpbx-help-icon" data-for="openldap-displayname"></i>
+					</div>
+					<div class="col-md-9">
+						<input id="openldap-displayname" name="openldap-displayname" type="text" class="form-control" value="<?php echo isset($config['displayname']) ? $config['displayname'] : 'displayname' ?>">
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-md-12">
+			<span id="openldap-displayname-help" class="help-block fpbx-help-block"><?php echo _("The OpenLDAP Display Name. Usually is displayname")?></span>
+		</div>
+	</div>
+</div>
+<div class="element-container">
+	<div class="row">
+		<div class="col-md-12">
+			<div class="row">
+				<div class="form-group">
+					<div class="col-md-3">
 						<label class="control-label" for="openldap-userdn"><?php echo _("User DN")?></label>
 						<i class="fa fa-question-circle fpbx-help-icon" data-for="openldap-userdn"></i>
 					</div>


### PR DESCRIPTION
This pull request add a Display Name field in User Manager authentication settings for ldap in order to bind the Display Name field in the users' table with a custom field in ldap (default is displayname).