### PR TITLE
Add usage info (FREEPBX-12690)

### DIFF
--- a/Userman.class.php
+++ b/Userman.class.php
@@ -589,10 +589,12 @@ class Userman extends \FreePBX_Helpers implements \BMO {
 					$assigned = $this->getGlobalSettingByID($request['user'],'assigned');
 					$assigned = !(empty($assigned)) ? $assigned : array();
 					$default = $user['default_extension'];
+					$usage_html = \FreePBX::View()->destinationUsage("ext-fax,$request[user],1");
 				} else {
 					$user = array();
 					$assigned = array();
 					$default = null;
+					$usage_html = '';
 				}
 				$extrauserdetails = $this->getExtraUserDetailsDisplay($user);
 				$fpbxusers = array();
@@ -638,7 +640,8 @@ class Userman extends \FreePBX_Helpers implements \BMO {
 						"user" => $user,
 						"message" => $this->message,
 						"permissions" => $permissions,
-						"extrauserdetails" => $extrauserdetails
+						"extrauserdetails" => $extrauserdetails,
+						"usage_html" => $usage_html,
 					)
 				);
 			break;

--- a/views/users.php
+++ b/views/users.php
@@ -7,6 +7,7 @@ if(isset($_REQUEST['action']) && $_REQUEST['action'] == 'showuser'){
 $formaction = 'config.php?display=userman#users';
 
 echo $heading;
+echo $usage_html;
 ?>
 <div class="container-fluid">
 	<div class="row">


### PR DESCRIPTION
One more, by internal request. I hard-coded `ext-fax` as the destination, I think "fax recipient" is the only way a user can be a destination for anything. Screenshot:

<img width="1165" alt="screenshot 2017-05-02 13 51 18" src="https://cloud.githubusercontent.com/assets/1329102/25638836/8cae3426-2f3e-11e7-9a65-25d011050868.png">
