### PR TITLE
openldap2 and msad2 views: fix secure connection select

### DIFF
--- a/views/msad2.php
+++ b/views/msad2.php
@@ -9,9 +9,9 @@
 					</div>
 					<div class="col-md-9">
 						<select id="msad2-connection" data-default="<?php echo $defaults['connection']?>" name="msad2-connection" class="form-control">
-							<option <?php $config['connection'] == '' ? 'selected' : ''?>><?php echo _("None")?></option>
-							<option <?php $config['connection'] == 'tls' ? 'selected' : ''?>>Start TLS</option>
-							<option <?php $config['connection'] == 'ssl' ? 'selected' : ''?>>SSL</option>
+							<option value='' <?php echo $config['connection'] == '' ? 'selected' : ''?>><?php echo _("None")?></option>
+							<option value='tls' <?php echo $config['connection'] == 'tls' ? 'selected' : ''?>>Start TLS</option>
+							<option value='ssl' <?php echo $config['connection'] == 'ssl' ? 'selected' : ''?>>SSL</option>
 						</select>
 					</div>
 				</div>

--- a/views/openldap2.php
+++ b/views/openldap2.php
@@ -9,9 +9,9 @@
 					</div>
 					<div class="col-md-9">
 						<select id="openldap2-connection" data-default="<?php echo $defaults['connection']?>" name="openldap2-connection" class="form-control">
-							<option <?php $config['connection'] == '' ? 'selected' : ''?>><?php echo _("None")?></option>
-							<option <?php $config['connection'] == 'tls' ? 'selected' : ''?>>Start TLS</option>
-							<option <?php $config['connection'] == 'ssl' ? 'selected' : ''?>>SSL</option>
+							<option value='' <?php echo $config['connection'] == '' ? 'selected' : ''?>><?php echo _("None")?></option>
+							<option value='tls' <?php echo $config['connection'] == 'tls' ? 'selected' : ''?>>Start TLS</option>
+							<option value='ssl' <?php echo $config['connection'] == 'ssl' ? 'selected' : ''?>>SSL</option>
 						</select>
 					</div>
 				</div>


### PR DESCRIPTION
Before the fix, connection variable was setted to ''|Start TLS|SSL, but accepted values were ''|tls|ssl.
Now variable is setted with correct values