### PR TITLE
Added multi-ldap host support

### DIFF
--- a/functions.inc/auth/modules/Msad2.php
+++ b/functions.inc/auth/modules/Msad2.php
@@ -739,28 +739,29 @@ class Msad2 extends Auth {
 	}
 
 	private function serviceping($hosts, $port=389, $timeout=1) {
-        foreach (preg_split("/[ ,]/", $hosts) as $host) {
-            $op = @fsockopen($host, $port, $errno, $errstr, $timeout);
-            if ($op) {
-                fclose($op); //explicitly close open socket connection
-                return 1; //DC is up & running, 
-                          //we can safely connect with ldap_connect
-            }
-        }
-        return 0; //DC is N/A 
-    }
+		foreach (preg_split("/[ ,]/", $hosts) as $host) {
+			$op = @fsockopen($host, $port, $errno, $errstr, $timeout);
+			if ($op) {
+				fclose($op); //explicitly close open socket connection
+				return 1; //DC is up & running, 
+						  //we can safely connect with ldap_connect
+			}
+		}
+		return 0; //DC is N/A 
+	}
 
 	private function buildldapuri($connection, $hosts, $port) {
 	    $securearray = array("ldaps", "ssl");
 		$uriarray = array();
 		if (in_array($connection, $securearray)) {
-		  $proto = 'ldaps';
+			$proto = 'ldaps';
 		} else {
-		  $proto = 'ldap';
+			$proto = 'ldap';
 		}
-        foreach (preg_split("/[ ,]/", $hosts) as $host) {
-		  array_push($uriarray, $proto . "://" . $host . ":" . $port);
+		foreach (preg_split("/[ ,]/", $hosts) as $host) {
+			array_push($uriarray, $proto . "://" . $host . ":" . $port);
 		}
 		return implode(" ", $uriarray);
 	}
 }
+

--- a/functions.inc/auth/modules/Msad2.php
+++ b/functions.inc/auth/modules/Msad2.php
@@ -219,8 +219,8 @@ class Msad2 extends Auth {
 			if(!$this->serviceping($this->config['host'], $this->config['port'], $this->timeout)) {
 				throw new \Exception("Unable to Connect to ".$this->config['host']."!");
 			}
-			$protocol = ($this->config['connection'] == 'ssl') ? 'ldaps' : 'ldap';
-			$this->ldap = ldap_connect($protocol.'://'.$this->config['host'].":".$this->config['port']);
+           $this->ldap = ldap_connect(buildldapuri($this->config['connection'],
+ $this->config['host'], $this->config['port']));
 			if($this->ldap === false) {
 				$this->ldap = null;
 				throw new \Exception("Unable to Connect");
@@ -516,7 +516,8 @@ class Msad2 extends Auth {
 		$this->connect();
 		$userdn = !empty($this->config['userdn']) ? $this->config['userdn'].",".$this->config['dn'] : $this->config['dn'];
 		$groupdn = !empty($this->config['groupdnaddition']) ? $this->config['groupdnaddition'].",".$this->config['dn'] : $this->config['dn'];
-		$this->out("\t".'ldapsearch -w '.$this->config['password'].' -h '.$this->config['host'].' -p '.$this->config['port'].'  -D "'.$this->config['username'].'@'.$this->config['domain'].'" -b "'.$groupdn.'" -s sub "(&'.$this->config['groupobjectfilter'].'(objectclass='.$this->config['groupobjectclass'].'))"');
+		$ldapuri = buildldapuri($this->config['connection'], $this->config['host'], $this->config['port']));
+		$this->out("\t".'ldapsearch -w '.$this->config['password'].' -H "'.$ldapuri.'" -D "'.$this->config['username'].'@'.$this->config['domain'].'" -b "'.$groupdn.'" -s sub "(&'.$this->config['groupobjectfilter'].'(objectclass='.$this->config['groupobjectclass'].'))"');
 		$this->out("\tRetrieving all groups...");
 		//(".$this->config['usermodifytimestampattr'].">=20010301000000Z)
 		$sr = ldap_search($this->ldap, $groupdn, "(&".$this->config['groupobjectfilter']."(objectclass=".$this->config['groupobjectclass']."))", array("*",$this->config['groupgidnumberattr']));
@@ -596,7 +597,8 @@ class Msad2 extends Auth {
 		$this->connect();
 
 		$userdn = !empty($this->config['userdn']) ? $this->config['userdn'].",".$this->config['dn'] : $this->config['dn'];
-		$this->out("\t".'ldapsearch -w '.$this->config['password'].' -h '.$this->config['host'].' -p '.$this->config['port'].' -D "'.$this->config['username'].'@'.$this->config['domain'].'" -b "'.$userdn.'" -s sub "(&'.$this->config['userobjectfilter'].'(objectclass='.$this->config['userobjectclass'].'))"');
+        $ldapuri = buildldapuri($this->config['connection'], $this->config['host'], $this->config['port']));
+		$this->out("\t".'ldapsearch -w '.$this->config['password'].' -H "'.$ldapuri.'" -D "'.$this->config['username'].'@'.$this->config['domain'].'" -b "'.$userdn.'" -s sub "(&'.$this->config['userobjectfilter'].'(objectclass='.$this->config['userobjectclass'].'))"');
 		$this->out("\tRetrieving all users...");
 
 		$sr = ldap_search($this->ldap, $userdn, "(&".$this->config['userobjectfilter']."(objectclass=".$this->config['userobjectclass']."))", array('*'));
@@ -736,13 +738,29 @@ class Msad2 extends Auth {
 		}
 	}
 
-	private function serviceping($host, $port=389, $timeout=1) {
-		$op = @fsockopen($host, $port, $errno, $errstr, $timeout);
-		if (!$op) {
-			return 0; //DC is N/A
+	private function serviceping($hosts, $port=389, $timeout=1) {
+        foreach (preg_split("/[ ,]/", $hosts) as $host) {
+            $op = @fsockopen($host, $port, $errno, $errstr, $timeout);
+            if ($op) {
+                fclose($op); //explicitly close open socket connection
+                return 1; //DC is up & running, 
+                          //we can safely connect with ldap_connect
+            }
+        }
+        return 0; //DC is N/A 
+    }
+
+	private function buildldapuri($connection, $hosts, $port) {
+	    $securearray = array("ldaps", "ssl");
+		$uriarray = array();
+		if (in_array($connection, $securearray)) {
+		  $proto = 'ldaps';
 		} else {
-			fclose($op); //explicitly close open socket connection
+		  $proto = 'ldap';
 		}
-		return 1; //DC is up & running, we can safely connect with ldap_connect
+        foreach (preg_split("/[ ,]/", $hosts) as $host) {
+		  array_push($uriarray, $proto . "://" . $host . ":" . $port);
+		}
+		return implode(" ", $uriarray);
 	}
 }

--- a/functions.inc/auth/modules/Openldap2.php
+++ b/functions.inc/auth/modules/Openldap2.php
@@ -727,29 +727,30 @@ class Openldap2 extends Auth {
 		}
 	}
 
-    private function serviceping($hosts, $port=389, $timeout=1) {
-        foreach (preg_split("/[ ,]/", $hosts) as $host) {
-            $op = @fsockopen($host, $port, $errno, $errstr, $timeout);
-            if ($op) {
-                fclose($op); //explicitly close open socket connection
-                return 1; //DC is up & running,
-                          //we can safely connect with ldap_connect
-            }
-        }
-        return 0; //DC is N/A
-    }
+	private function serviceping($hosts, $port=389, $timeout=1) {
+		foreach (preg_split("/[ ,]/", $hosts) as $host) {
+			$op = @fsockopen($host, $port, $errno, $errstr, $timeout);
+			if ($op) {
+				fclose($op); //explicitly close open socket connection
+				return 1; //DC is up & running, 
+						  //we can safely connect with ldap_connect
+			}
+		}
+		return 0; //DC is N/A 
+	}
 
-    private function buildldapuri($connection, $hosts, $port) {
-        $securearray = array("ldaps", "ssl");
-        $uriarray = array();
-        if (in_array($connection, $securearray)) {
-          $proto = 'ldaps';
-        } else {
-          $proto = 'ldap';
-        }
-        foreach (preg_split("/[ ,]/", $hosts) as $host) {
-          array_push($uriarray, $proto . "://" . $host . ":" . $port);
-        }
-        return implode(" ", $uriarray);
-    }
+	private function buildldapuri($connection, $hosts, $port) {
+	    $securearray = array("ldaps", "ssl");
+		$uriarray = array();
+		if (in_array($connection, $securearray)) {
+			$proto = 'ldaps';
+		} else {
+			$proto = 'ldap';
+		}
+		foreach (preg_split("/[ ,]/", $hosts) as $host) {
+			array_push($uriarray, $proto . "://" . $host . ":" . $port);
+		}
+		return implode(" ", $uriarray);
+	}
 }
+

--- a/functions.inc/auth/modules/Openldap2.php
+++ b/functions.inc/auth/modules/Openldap2.php
@@ -229,7 +229,8 @@ class Openldap2 extends Auth {
 				throw new \Exception("Unable to Connect to ".$this->config['host']."!");
 			}
 			$protocol = ($this->config['connection'] == 'ssl') ? 'ldaps' : 'ldap';
-			$this->ldap = ldap_connect($protocol.'://'.$this->config['host'].":".$this->config['port']);
+			$this->ldap = ldap_connect(buildldapuri($this->config['connection'],
+ $this->config['host'], $this->config['port']));
 			if($this->ldap === false) {
 				$this->ldap = null;
 				throw new \Exception("Unable to Connect");
@@ -524,7 +525,8 @@ class Openldap2 extends Auth {
 		$this->connect();
 		$userdn = !empty($this->config['userdn']) ? $this->config['userdn'].",".$this->config['basedn'] : $this->config['basedn'];
 		$groupdn = !empty($this->config['groupdnaddition']) ? $this->config['groupdnaddition'].",".$this->config['basedn'] : $this->config['basedn'];
-		$this->out("\t".'ldapsearch -w '.$this->config['password'].' -h '.$this->config['host'].' -p '.$this->config['port'].'  "'.$this->config['username'].'" -b "'.$groupdn.'" -s sub "'.$this->config['groupobjectfilter'].'"');
+        $ldapuri = buildldapuri($this->config['connection'], $this->config['host'], $this->config['port']));
+		$this->out("\t".'ldapsearch -w '.$this->config['password'].' -H "'.$ldapuri.'" -D "'.$this->config['username'].'" -b "'.$groupdn.'" -s sub "'.$this->config['groupobjectfilter'].'"');
 		$this->out("\tRetrieving all groups...");
 		//(".$this->config['usermodifytimestampattr'].">=20010301000000Z)
 		$sr = ldap_search($this->ldap, $groupdn, "(&".$this->config['groupobjectfilter']."(objectclass=".$this->config['groupobjectclass']."))", array("*",$this->config['groupgidnumberattr'],$this->config['descriptionattr'],$this->config['commonnameattr'], $this->config['externalidattr'], $this->config['groupmemberattr']));
@@ -605,7 +607,8 @@ class Openldap2 extends Auth {
 		$this->connect();
 
 		$userdn = !empty($this->config['userdn']) ? $this->config['userdn'].",".$this->config['basedn'] : $this->config['basedn'];
-		$this->out("\t".'ldapsearch -w '.$this->config['password'].' -h '.$this->config['host'].' -p '.$this->config['port'].'  "'.$this->config['username'].'" -b "'.$userdn.'" -s sub "'.$this->config['userobjectfilter'].'" "'.$this->config['externalidattr'].'=*" '.$this->config['externalidattr']);
+		$ldapuri = buildldapuri($this->config['connection'], $this->config['host'], $this->config['port']));
+		$this->out("\t".'ldapsearch -w '.$this->config['password'].' -H "'.$ldapuri.'" -D "'.$this->config['username'].'" -b "'.$userdn.'" -s sub "'.$this->config['userobjectfilter'].'" "'.$this->config['externalidattr'].'=*" '.$this->config['externalidattr']);
 		$this->out("\tRetrieving all users...");
 		//(".$this->config['groupmodifytimestampattr'].">=20010301000000Z)
 		$sr = ldap_search($this->ldap, $userdn, "(&".$this->config['userobjectfilter']."(objectclass=".$this->config['userobjectclass']."))", array('*',$this->config['externalidattr']));
@@ -724,13 +727,29 @@ class Openldap2 extends Auth {
 		}
 	}
 
-	private function serviceping($host, $port=389, $timeout=1) {
-		$op = @fsockopen($host, $port, $errno, $errstr, $timeout);
-		if (!$op) {
-			return 0; //DC is N/A
-		} else {
-			fclose($op); //explicitly close open socket connection
-		}
-		return 1; //DC is up & running, we can safely connect with ldap_connect
-	}
+    private function serviceping($hosts, $port=389, $timeout=1) {
+        foreach (preg_split("/[ ,]/", $hosts) as $host) {
+            $op = @fsockopen($host, $port, $errno, $errstr, $timeout);
+            if ($op) {
+                fclose($op); //explicitly close open socket connection
+                return 1; //DC is up & running,
+                          //we can safely connect with ldap_connect
+            }
+        }
+        return 0; //DC is N/A
+    }
+
+    private function buildldapuri($connection, $hosts, $port) {
+        $securearray = array("ldaps", "ssl");
+        $uriarray = array();
+        if (in_array($connection, $securearray)) {
+          $proto = 'ldaps';
+        } else {
+          $proto = 'ldap';
+        }
+        foreach (preg_split("/[ ,]/", $hosts) as $host) {
+          array_push($uriarray, $proto . "://" . $host . ":" . $port);
+        }
+        return implode(" ", $uriarray);
+    }
 }


### PR DESCRIPTION
This is an attempt to leverage OpenLDAP v2's ability to specify multiple LDAP URIs to improve the resilience in a way that specifying just a single server can not.  The serviceping function will return successful as long as at least one specified host access a socket connection.  The buildldapuri will then use a space or comma delimited list of hosts along with the specified connection protocol and port to build a list or LDAP URIs.  This string should then work for being passed to PHP's ldap_connect and ldapsearch with the -H flag.

Without these changes, only a single host can be specified and any problem connecting or binding to that single host will result in the LDAP call failing despite that the environment may provide replication to additional LDAP servers to provide high availability of the LDAP service.