### PR TITLE
Fixing port on ldap issue

### DIFF
--- a/views/openldap2.php
+++ b/views/openldap2.php
@@ -52,7 +52,7 @@
 			<div class="row">
 				<div class="form-group">
 					<div class="col-md-3">
-						<label class="control-label" for="openldap2-post"><?php echo _("Port")?></label>
+						<label class="control-label" for="openldap2-port"><?php echo _("Port")?></label>
 						<i class="fa fa-question-circle fpbx-help-icon" data-for="openldap2-port"></i>
 					</div>
 					<div class="col-md-9">


### PR DESCRIPTION
Hello FreePBX devs,
hope ur all doing great. I noticed that changing the port is not possible, because the name of the label in the frontend is wrong. I am able to change it if I manually rename the label from `openldap2-post` to `openldap2-port` it works. is a huge pita though because on every save it defaults back to 389. 