### PR TITLE
issues/473 fix:decode sanitized password input before DB operations

### DIFF
--- a/Userman.class.php
+++ b/Userman.class.php
@@ -520,7 +520,7 @@ class Userman extends FreePBX_Helpers implements BMO {
 
 					$directory = $request['directory'];
 					$username = !empty($request['username']) ? $request['username'] : '';
-					$password = !empty($request['password']) ? $request['password'] : '';
+					$password = !empty($request['password']) ? htmlspecialchars_decode($request['password']) : '';
 					$description = !empty($request['description']) ? $request['description'] : '';
 					$prevUsername = !empty($request['prevUsername']) ? $request['prevUsername'] : '';
 					$prevEmail = !empty($request['prevEmail']) ? $request['prevEmail'] : '';


### PR DESCRIPTION
The 'freepbxGetSanitizedRequest' function sanitizes all inputs using FILTER_SANITIZE_FULL_SPECIAL_CHARS, which encodes '&' as '&amp;'. This caused issues with authentication where special characters like '&' are valid in passwords.
